### PR TITLE
Refix my readd

### DIFF
--- a/Incremental.c
+++ b/Incremental.c
@@ -1612,7 +1612,7 @@ static int Incremental_container(struct supertype *st, char *devname,
 		}
 
 		assemble_container_content(st, mdfd, ra, c,
-								   chosen_name, -1, &result);
+								   chosen_name, NULL, &result);
 		close(mdfd);
 	}
 	if (c->export && result) {

--- a/Manage.c
+++ b/Manage.c
@@ -840,9 +840,9 @@ int attempt_re_add(int fd, int tfd, struct mddev_dev *dv,
 			}
 			sra->array.level = LEVEL_CONTAINER;
 			mdi.disk = disc;
-			mdi.recovery_start = 1;
+			mdi.recovery_start = 0;
 			pr_err("re-adding back previous non-faulty disk\n");
-			if (sysfs_add_disk(sra, &mdi, 0) != 0) {
+			if (sysfs_add_disk(sra, &mdi, 1) != 0) {
 				pr_err("add new device to external metadata failed for %s\n", dv->devname);
 				close(container_fd);
 				sysfs_free(sra);

--- a/bitmap.h
+++ b/bitmap.h
@@ -176,6 +176,9 @@ typedef struct bitmap_super_s {
  *    devices.  For raid10 it is the size of the array.
  */
 
+#define BITMAP_EVENTS_CLEARED_DONTSET -1
+#define BITMAP_EVENTS_CLEARED_INITIAL  1
+
 #ifdef __KERNEL__
 
 /* the in-memory bitmap is represented by bitmap_pages */

--- a/mdadm.h
+++ b/mdadm.h
@@ -1476,10 +1476,9 @@ extern unsigned long long calc_array_size(int level, int raid_disks, int layout,
 extern int flush_metadata_updates(struct supertype *st);
 extern void append_metadata_update(struct supertype *st, void *buf, int len);
 extern int assemble_container_content(struct supertype *st, int mdfd,
-									  struct mdinfo *content,
-									  struct context *c,
-									  char *chosen_name, int bitmap_fd,
-									  int *result);
+				      struct mdinfo *content, struct context *c,
+				      char *chosen_name, struct mddev_ident *ident,
+				      int *result);
 #define	INCR_NO		1
 #define	INCR_UNSAFE	2
 #define	INCR_ALREADY	4
@@ -1758,3 +1757,9 @@ char *xstrdup(const char *str);
 #define INVALID_SECTORS 1
 /* And another special number needed for --data_offset=variable */
 #define VARIABLE_OFFSET 3
+
+
+//////////////////////////////////////////////////////////////////////////////
+/// initialize and inform the kernel of a bitmap file if needed
+//////////////////////////////////////////////////////////////////////////////
+int set_bitmap_file(struct mddev_ident *ident, int mdfd, int events_cleared);

--- a/super-ddf.c
+++ b/super-ddf.c
@@ -3157,9 +3157,11 @@ static int add_to_super_ddf(struct supertype *st,
 	if (dk->raid_disk >= 0) {
 		dd->readd = 1;
 		dd->state = dk->state;
+		dd->raiddisk = dk->raid_disk;
 	} else {
 		dd->readd = 0;
 		dd->state = 0;
+		dd->raiddisk = -1;
 	}
 
 	dd->disk.magic = DDF_PHYS_DATA_MAGIC;
@@ -5726,7 +5728,7 @@ static struct mdinfo *ddf_activate_spare(struct active_array *a,
 			di->disk.major = dl->major;
 			di->disk.minor = dl->minor;
 			di->disk.state = dl->readd ? dl->state : 0;
-			di->recovery_start = dl->readd ? MaxSector : 0;
+			di->recovery_start = 0;
 			di->data_offset = pos;
 			di->component_size = a->info.component_size;
 			di->next = rv;


### PR DESCRIPTION
Two commits here:

Author: Stephen Rust <srust@blockbridge.com>
Date:   Fri Sep 14 11:55:51 2018 -0400

    Set events_cleared in bitmap file to ensure assembly bitmap recovery
    
    The kernel checks array 'events' with bitmap 'events_cleared'. If they
    are the same, then the bits loaded in the bitmap on assembly are
    discarded, even on a degraded array. This is a specific bug for external
    (ie: ddf) metadata, as external metadata has no interface and no ability
    to set the array 'events' to keep the kernel informed and in-sync.
    
    Workaround this lack of 'events' tracking, so that bitmap load *flags*
    the bits in the bitmap as NEEDED for a degraded array, by writing
    a bogus non-zero 'events_cleared' value to the bitmap file during mdadm
    assembly. As external metadata can only be used with a bitmap file
    (internal bitmaps not supported), and because the 'events_cleared' value
    only has to be *different* during bitmap load in the kernel, any
    non-zero value works. Once the bitmap has been loaded and flushed, the
    bitmap superblock is updated in the kernel resetting it to 0. But the
    bits have been loaded correctly, and are not cleared.
    
    A drive re-add will use the bitmap for recovery correctly.

Author: Stephen Rust <srust@blockbridge.com>
Date:   Fri Sep 14 11:51:09 2018 -0400

    Ensure disk recovery starts for container re-add
    
    A re-add must recover the added disk from the beginning. This ensures
    that the entire bitmap is consulted when resyncing the added disk. In
    the re-add case, set recovery_start to 0 for the disk as part of the
    sysfs dance (the order between insync, recovery_start is critical).
    mdmon here does the real work, by passing "resume" into the sysfs
    function to do the re-add.
    
    Also, fix a bug with raid_disk reporting. This fixes the log message
    issue where a re-added disk had -1 printed, even though it had been
    assigned a correct raid_disk.
