### PR TITLE
Re-add possible only if disk is MD_DISK_SYNC.

### DIFF
--- a/Create.c
+++ b/Create.c
@@ -630,10 +630,10 @@ int Create(struct supertype *st, char *mddev,
 	}
 
 	/* Ok, lets try some ioctls */
-
 	info.array.level = s->level;
 	info.array.size = s->size;
 	info.array.raid_disks = s->raiddisks;
+
 	/* The kernel should *know* what md_minor we are dealing
 	 * with, but it chooses to trust me instead. Sigh
 	 */
@@ -883,8 +883,7 @@ int Create(struct supertype *st, char *mddev,
 					inf->disk.state = (1<<MD_DISK_JOURNAL);
 					raid_disk_num--;
 				} else if (inf->disk.raid_disk < s->raiddisks)
-					inf->disk.state = (1<<MD_DISK_ACTIVE) |
-						(1<<MD_DISK_SYNC);
+					inf->disk.state = (1<<MD_DISK_ACTIVE) | (1<<MD_DISK_SYNC);
 				else
 					inf->disk.state = 0;
 


### PR DESCRIPTION
Fallback on re-add for a "rebuilding" disk, to treat it as a new "add".
This ensures that if rebuild/recovery/initial-sync did not complete,
that we do not perform bitmap recovery on the added disk. The add gets
treated directly as a new "add", and the disk recovery starts over.

Implement this by respecting the MD_DISK_SYNC flag, and only setting this flag if the DDF metadata says the disk is *NOT* DDF_Rebuilding. Once the disk is full part of the array, the DDF_Rebuilding flag is unset, and the MD_DISK_SYNC flag will be set.

There is only *ONE* case, in `super-ddf` where the MD_DISK_SYNC flag is checked, and this is during the "Create" path. For a Create, MD_DISK_SYNC and MD_DISK_ACTIVE are *always* set, so this check continue to be valid.

We add the check and comparison to `mdmon`, so that we ensure that the *state* of the disk is valid, and it is MD_DISK_SYNC. However, due to the "fallback" to an "add" new, we should never this in `mdmon`. It is there as a precaution to protect ourselves. In the "add" new case, where `mdadm` falls back to an "add" when the disk is not MD_DISK_SYNC and the "re-add" is not possible, the `mdadm` will initialize the disk as "new". `mdmon` then treats it as "new" and performs a new add in the `managemon` `add_disk_to_container`.