### PR TITLE
Probe device before add in mdadm and mdmon

### DIFF
--- a/Manage.c
+++ b/Manage.c
@@ -999,7 +999,14 @@ int Manage_add(int fd, int tfd, struct mddev_dev *dv,
 		 * simply re-add it.
 		 */
 		dev_st = dup_super(tst);
-		dev_st->ss->load_super(dev_st, tfd, NULL);
+		dev_st->ss->load_super(dev_st, tfd, verbose > 0 ? dv->devname : NULL);
+
+		if (!dev_st->ss->probe_device_fd(dev_st, tfd)) {
+			pr_err("Cannot add device %s to %s: device is OFFLINE.\n",
+				   dv->devname, devname);
+			return -1;
+		}
+
 		if (dev_st->sb && dv->disposition != 'S') {
 			int rv;
 

--- a/managemon.c
+++ b/managemon.c
@@ -417,6 +417,11 @@ static void add_disk_to_container(struct supertype *st, struct mdinfo *sd,
 					"exiting!\n", __FUNCTION__);
 				exit(1);
 			}
+
+			if (!a->container->ss->probe_device_fd(a->container, dfd)) {
+				dprintf("add failed for %s: device is OFFLINE\n", nm);
+				return;
+			}
 		}
 	}
 

--- a/mdadm.h
+++ b/mdadm.h
@@ -1077,6 +1077,9 @@ extern struct superswitch {
 	/* return nonzero if enough devices are readable */
 	int (*probe_devices)(struct active_array *a);
 
+	/* return nonzero if device fd is readable */
+	int (*probe_device_fd)(struct supertype *st, int fd);
+
     /* return external minimum assembly sequence number */
 	int64_t (*get_assembly_seq)(struct supertype *st);
 


### PR DESCRIPTION
Before adding a device to a container, probe the device to make sure it
is online. This does a simple read probe, the same as our mdmon device
probe.

We probe _before_ doing a re-add/add in mdadm. Also, if the device goes
offline after mdadm, but before mdmon wakes up and adds the disk to the
container, we probe *again* in mdmon before updating the metadata.

Without the probe, we attempt to read the metadata for the device (and
cannot do so because it is offline) and then treat the disk as a "new"
device being added to the array. mdmon wakes up, adds the disk to the
container, updates everyone elses metatadata. But the disk added is
immediately faulty because it is offline. So mdmon then removes it. The
removal triggers an mdvote "member" event increment, which then triggers
the offline device as no longer a valid member of the array. When it
does eventually come back online, even if no new replacement was added
to the array in the meanwhile, this otherwise valid disk cannot be
re-added, and we must wait until time2repair for the volume when an
unmap of the device and an add as new takes place. So, we lose the
ability to bitmap recover this offline device and must take a full
resync.

This probe addresses this issue, so we don't make forward progress in
the array membership when we shouldn't.