### PR TITLE
Fix two memory leaks and an uninitialized read

### DIFF
--- a/sysfs.c
+++ b/sysfs.c
@@ -105,7 +105,7 @@ struct mdinfo *sysfs_read(int fd, char *devnm, unsigned long options)
 	char buf[PATH_MAX];
 	char *base;
 	char *dbase;
-	struct mdinfo *sra;
+	struct mdinfo *sra = NULL;
 	struct mdinfo *dev, **devp;
 	DIR *dir = NULL;
 	struct dirent *de;


### PR DESCRIPTION
The ddf_probe_device_fd() failed to respect the 'static' nature of the
posix_memaligned buffer, after the last change. Move back to only
allocating the buffer once and re-using it. Also fix an unitialized read
for the printf in here.

sysfs_read() returns an allocated mdinfo, but most (all?) cases did not
free it. Have the callers free the memory using sysfs_free().