### PR TITLE
Always update array state on membership changes

### DIFF
--- a/managemon.c
+++ b/managemon.c
@@ -299,6 +299,7 @@ static void remove_disk_from_container(struct supertype *st, struct mdinfo *sd)
 
 	st->update_tail = &update;
 	st->ss->remove_from_super(st, &dk);
+	st->ss->update_state(st);
 
 	/* FIXME this write_init_super shouldn't be here.
 	 * We have it after add_to_super to write to new device,
@@ -430,6 +431,7 @@ static void add_disk_to_container(struct supertype *st, struct mdinfo *sd,
 	// add or re-add
 	st->update_tail = &update;
 	st->ss->add_to_super(st, &dk, dfd, NULL, INVALID_SECTORS);
+	st->ss->update_state(st);
 	st->ss->write_init_super(st);
 	queue_metadata_update(update);
 	st->update_tail = NULL;

--- a/mdadm.h
+++ b/mdadm.h
@@ -1015,6 +1015,11 @@ extern struct superswitch {
 	 */
 	int (*set_array_state)(struct active_array *a, int consistent);
 
+	/*
+	 * Update array "state". The virtual subarray state.
+	 */
+	int (*update_state)(struct supertype *st);
+
 	/* When the state of a device might have changed, we call set_disk to
 	 * tell the metadata what the current state is.
 	 * Typically this happens on spare->in_sync and (spare|in_sync)->faulty


### PR DESCRIPTION
A specific sequence of disk failures and a race with the kernel
signaling to remove a disk from the array, can cause an array to lose
a member disk but not have the metadata persistently mark the array as
degraded.

The sequence is:

  * disk goes away (dev entry missing / gone)
  * disk is removed from container, tracking structures zeroed out
  * kernel says disk is "faulty".
  * attempt to mark the faulty disk as "faulty"
  * skip it ; disk doesn't exist ; array metadata never marked degraded

Later, due to this missing degraded, when a new replacement disk is
*added*, the array is not degraded, and this new disk is not marked
rebuilding. However, the new disk *must* be marked rebuilding. And the
array *must* be marked degraded so additional checks/logic can be
performed.

Ensure correct array state by updating it *always*, even if the original
disk goes away. And also check it specifically again on disk *add* and
disk *remove*. This catches and closes other races with updating the
array to degraded during reboots/failover.