### PR TITLE
assemble_container_content: skip devices already in container but are not up to minimum assembly sequence

### DIFF
--- a/.lvimrc
+++ b/.lvimrc
@@ -1,0 +1,3 @@
+set tabstop=8
+set shiftwidth=8
+set noexpandtab

--- a/Incremental.c
+++ b/Incremental.c
@@ -1612,7 +1612,7 @@ static int Incremental_container(struct supertype *st, char *devname,
 		}
 
 		assemble_container_content(st, mdfd, ra, c,
-								   chosen_name, NULL, &result);
+								   chosen_name, NULL, 0, &result);
 		close(mdfd);
 	}
 	if (c->export && result) {

--- a/mdadm.h
+++ b/mdadm.h
@@ -1486,7 +1486,8 @@ extern void append_metadata_update(struct supertype *st, void *buf, int len);
 extern int assemble_container_content(struct supertype *st, int mdfd,
 				      struct mdinfo *content, struct context *c,
 				      char *chosen_name, struct mddev_ident *ident,
-				      int *result);
+				      int64_t min_assembly_seq, int *result);
+extern int get_assembly_seq(struct context *c, struct supertype *st, int64_t *seq_out);
 #define	INCR_NO		1
 #define	INCR_UNSAFE	2
 #define	INCR_ALREADY	4


### PR DESCRIPTION
An mdvote check was missing from assemble_container_content(). This is
the codepath in assembly where the DDF container (ie: bb:bitmap-array:c)
is assembled, but before the member array is assembled. When the member
array is assembled, ie:

	mdadm --assemble /dev/md/bb:bitmap-array /dev/md/bb:bitmap-array:c

It goes through the assemble_container_content() codepath. In this code,
there was no mdvote check. So if the container was assembled while the
devices had a valid assembly sequence, but that later the member array
was assembled when those devices no longer had a valid assembly
sequence, the missing mdvote check would allow the member array to
start, incorrectly, with a stale out of date device.

This is actually pretty easy to reproduce, by partially stopping an
array and then assembling with only one device on the other member, as
follows:

cm1: assemble full array
----

	mdadm --assemble /dev/md/bb:bitmap-array:c /dev/ram1 /dev/sda
	mdadm --assemble /dev/md/bb:bitmap-array /dev/md/bb:bitmap-array:c

cm1: write to array to lock in sequence numbers
----

	mount /dev/md/bb:bitmap-array /bb/bitmap
	umount /bb/bitmap

cm1: stop member array
----

	mdadm --stop /dev/md/bb:bitmap-array

cm2: map local ramdisk and assemble
----

	diskctl --svc disk map --owner bitmap-array-XXXX-XXXX-XXX-XXX-XXXX --id local-ramdisk-id
	mdadm --assemble /dev/md/bb:bitmap-array-c /dev/ram1
	mdadm --assemble --run /dev/md/bb:bitmap-array /dev/md/bb:bitmap-array:c

cm2: write to array to roll forward sequence numbers
----

	mount /dev/md/bb:bitmap-array /bb/bitmap
	umount /bb/bitmap

cm1: assemble container content to member array
----

	mdadm --assemble --run /dev/md/bb:bitmap-array /dev/md/bb:bitmap-array:c

---

At this point, without the additional mdvote check in
assemble_container_content(), the array is allowed to assemble with the
old/stale drive in the container on cm1.

WITH this fix, the sequence number check is performed, the final step on
assembly on cm1 fails, and the array is not started, is marked as
failed.