### PR TITLE
Disk replacement

### DIFF
--- a/Manage.c
+++ b/Manage.c
@@ -1386,10 +1386,13 @@ int Manage_replace(struct supertype *tst, int fd, struct mddev_dev *dv,
 		   unsigned long rdev, int verbose, char *devname)
 {
 	struct mdinfo *mdi, *di;
+#if 0
 	if (tst->ss->external) {
 		pr_err("--replace only supported for native metadata (0.90 or 1.x)\n");
 		return -1;
 	}
+#endif
+
 	/* Need to find the device in sysfs and add 'want_replacement' to the
 	 * status.
 	 */
@@ -1830,10 +1833,12 @@ int Manage_subdevs(char *devname, int fd,
 					dv->devname, devname);
 			break;
 		case 'R': /* Mark as replaceable */
+#if 0
 			if (subarray) {
 				pr_err("Cannot replace disks in a \'member\' array, perform this operation on the parent container\n");
 				rv = -1;
 			} else {
+#endif
 				if (!frozen) {
 					if (sysfs_freeze_array(&info) == 1)
 						frozen = 1;
@@ -1843,7 +1848,9 @@ int Manage_subdevs(char *devname, int fd,
 				rv = Manage_replace(tst, fd, dv,
 						    rdev, verbose,
 						    devname);
+#if 0
 			}
+#endif
 			if (rv < 0)
 				goto abort;
 			if (rv > 0)

--- a/Manage.c
+++ b/Manage.c
@@ -1386,12 +1386,6 @@ int Manage_replace(struct supertype *tst, int fd, struct mddev_dev *dv,
 		   unsigned long rdev, int verbose, char *devname)
 {
 	struct mdinfo *mdi, *di;
-#if 0
-	if (tst->ss->external) {
-		pr_err("--replace only supported for native metadata (0.90 or 1.x)\n");
-		return -1;
-	}
-#endif
 
 	/* Need to find the device in sysfs and add 'want_replacement' to the
 	 * status.
@@ -1833,24 +1827,15 @@ int Manage_subdevs(char *devname, int fd,
 					dv->devname, devname);
 			break;
 		case 'R': /* Mark as replaceable */
-#if 0
-			if (subarray) {
-				pr_err("Cannot replace disks in a \'member\' array, perform this operation on the parent container\n");
-				rv = -1;
-			} else {
-#endif
-				if (!frozen) {
-					if (sysfs_freeze_array(&info) == 1)
-						frozen = 1;
-					else
-						frozen = -1;
-				}
-				rv = Manage_replace(tst, fd, dv,
-						    rdev, verbose,
-						    devname);
-#if 0
+			if (!frozen) {
+				if (sysfs_freeze_array(&info) == 1)
+					frozen = 1;
+				else
+					frozen = -1;
 			}
-#endif
+			rv = Manage_replace(tst, fd, dv,
+						rdev, verbose,
+						devname);
 			if (rv < 0)
 				goto abort;
 			if (rv > 0)

--- a/managemon.c
+++ b/managemon.c
@@ -644,16 +644,17 @@ static void manage_member(struct mdstat_ent *mdstat,
 		tv.tv_sec, tv.tv_usec);
 
 	for (mdi = a->info.devs; mdi; mdi = mdi->next) {
-		dprintf("array%d disk%d (%d:%d) state %d%s%s%s\n",
+		dprintf("array%d disk%d (%d:%d) state %d%s%s%s%s%s\n",
 			a->info.container_member,
 			mdi->disk.raid_disk,
 			mdi->disk.major,
 			mdi->disk.minor,
 			mdi->curr_state,
 			(mdi->curr_state & DS_INSYNC) ? ", online" : "",
-			mdi->remove ? ", removed" :
-		           mdi->replace ? ", wants_replacement" : "",
-		        mdi->faulty  ? ", faulty" : "");
+			mdi->remove ? ", removed" : "",
+		        mdi->faulty ? ", faulty" : "",
+		        ((mdi->curr_state & DS_WANT_REPLACEMENT) || mdi->replace) ? ", want_replacement" : "",
+		        (mdi->curr_state & DS_REPLACEMENT) ? ", replacement" : "");
 	}
 
 	if (sigterm && a->info.safe_mode_delay != 1) {
@@ -808,7 +809,7 @@ static void manage_member(struct mdstat_ent *mdstat,
 
 		/* check disk states for those wanting replacement */
 		for (d = info->devs; d; d = d->next) {
-			dprintf("disk in array: %d:%d state: %d\n",
+			dprintf("disk in array: %d:%d sysfs state: %d\n",
 				d->disk.major, d->disk.minor, d->disk.state);
 			if (d->disk.raid_disk < 0)
 				continue;

--- a/managemon.c
+++ b/managemon.c
@@ -886,6 +886,7 @@ out3:
 
 			/* check for replacement complete */
 			a->container->ss->replace_disk(a, &mdi->disk, &updates);
+			a->container->ss->update_state(a->container);
 
 			/* queue any wait for metadata update */
 			queue_metadata_update(updates);

--- a/managemon.c
+++ b/managemon.c
@@ -1171,6 +1171,8 @@ void do_manager(struct supertype *container)
 	sigdelset(&set, SIGUSR1);
 	sigdelset(&set, SIGTERM);
 
+	ThreadName = "manager:";
+
 	do {
 
 		if (exit_now)

--- a/managemon.c
+++ b/managemon.c
@@ -901,8 +901,13 @@ out3:
 				mdi->disk.major,
 				mdi->disk.minor);
 
-			/* check for replacement complete */
+			/* replace disk if able, otherwise fail replacement */
 			a->container->ss->replace_disk(a, &mdi->disk, &updates);
+
+			/* replace attempt complete */
+			mdi->replace = 0;
+
+			/* queue updates if replacement occurred */
 			if (updates) {
 				/* queue any wait for metadata update */
 				queue_metadata_update(updates);
@@ -911,6 +916,8 @@ out3:
 
 				/* now remove the faulty */
 				mdi->remove = 1;
+			} else {
+				wakeup_monitor();
 			}
 		}
 	}

--- a/managemon.c
+++ b/managemon.c
@@ -667,7 +667,7 @@ static void manage_member(struct mdstat_ent *mdstat,
 		/* The array may not be degraded, this is just a good time
 		 * to check.
 		 */
-		newdev = container->ss->activate_spare(a, &updates);
+		newdev = container->ss->activate_spare(a, 0, &updates);
 		if (!newdev)
 			return;
 
@@ -808,7 +808,7 @@ static void manage_member(struct mdstat_ent *mdstat,
 				d->disk.major, d->disk.minor);
 
 			/* Activate a replacement */
-			newdev = container->ss->activate_spare(a, &updates);
+			newdev = container->ss->activate_spare(a, 1, &updates);
 			if (!newdev)
 				continue;
 

--- a/managemon.c
+++ b/managemon.c
@@ -1199,7 +1199,7 @@ void do_manager(struct supertype *container)
 	struct mdstat_ent *mdstat;
 	sigset_t set;
 
-	ThreadName = "manager:";
+	Name = "manager";
 
 	do {
 		sigprocmask(SIG_UNBLOCK, NULL, &set);

--- a/managemon.c
+++ b/managemon.c
@@ -868,9 +868,9 @@ out3:
 	 *
 	 * Check whether we can replace a disk that "wants" replacement with
 	 * a fully synchronized replacement spare that was previously
-	 * activated. Perform a disk replacemenet, which updates the metadata,
+	 * activated. Perform a disk replacement, which updates the metadata,
 	 * replacing the "faulty, want_replacement" disk with the synchronized
-	 * "spare" in the same raid disk slot.
+	 * "spare,replacement" in the same raid disk slot.
 	 *
 	 * We don't check the array while any update is pending, as it might
 	 * contain a change (such as a spare assignment) which could affect our
@@ -891,7 +891,7 @@ out3:
 				continue;
 			}
 
-			/* disk marked for replacement in state or flag */
+			/* disk marked for replacement */
 			if (!mdi->replace) {
 			      	continue;
 			}

--- a/mdadm.c
+++ b/mdadm.c
@@ -39,6 +39,7 @@ static int misc_list(struct mddev_dev *devlist,
 		     char *dump_directory,
 		     struct supertype *ss, struct context *c);
 char Name[] = "mdadm";
+__thread const char *ThreadName = "";
 
 static int bb_compat = 0;
 

--- a/mdadm.c
+++ b/mdadm.c
@@ -38,8 +38,7 @@ static int misc_list(struct mddev_dev *devlist,
 		     struct mddev_ident *ident,
 		     char *dump_directory,
 		     struct supertype *ss, struct context *c);
-char Name[] = "mdadm";
-__thread const char *ThreadName = "";
+__thread const char *Name = "mdadm";
 
 static int bb_compat = 0;
 

--- a/mdadm.h
+++ b/mdadm.h
@@ -324,7 +324,9 @@ struct mdinfo {
 	#define DS_WRITE_ERROR  4096
 	#define DS_REPLACEMENT  8192
 	int prev_state, curr_state, next_state;
+	int faulty;
 	int replace;
+	int remove;
 
 	/* info read from sysfs */
 	char		sysfs_array_state[20];

--- a/mdadm.h
+++ b/mdadm.h
@@ -320,7 +320,8 @@ struct mdinfo {
 	#define DS_BLOCKED	16
 	#define	DS_REMOVE	1024
 	#define	DS_UNBLOCK	2048
-    #define DS_WRITE_ERROR 4096
+	#define DS_WRITE_ERROR  4096
+	#define DS_REPLACEMENT  8192
 	int prev_state, curr_state, next_state;
 
 	/* info read from sysfs */
@@ -1027,7 +1028,16 @@ extern struct superswitch {
 	 * set_disk might be called when the state of the particular disk has
 	 * not in fact changed.
 	 */
-	void (*set_disk)(struct active_array *a, int n, int state);
+	void (*set_disk)(struct active_array *a, mdu_disk_info_t *dsk, int state);
+
+	/* Complete the disk replacement. Once a replaced disk goes faulty,
+	 * replace it with the selected replacement in it's slot. This updates
+	 * the metadata to "move" the replacement disk down and replaces the
+	 * faulty disk.
+	 */
+	void (*replace_disk)(struct active_array *a, mdu_disk_info_t *dsk,
+			     struct metadata_update **updates);
+
 	int (*sync_metadata)(struct supertype *st);
 	void (*process_update)(struct supertype *st,
 			       struct metadata_update *update);

--- a/mdadm.h
+++ b/mdadm.h
@@ -324,6 +324,11 @@ struct mdinfo {
 	#define DS_WANT_REPLACEMENT (1 << 13)
 	#define DS_REPLACEMENT      (1 << 14)
 	int prev_state, curr_state, next_state;
+
+	/* store state booleans that we need to persist;
+	 * as the curr_state is updated and reset regularly.
+	 * As curr_state is the kernel state, the kernel may have
+	 * moved on, but we need to remember. */
 	int faulty;
 	int replace;
 	int remove;
@@ -1052,9 +1057,9 @@ extern struct superswitch {
 			       struct metadata_update *update);
 
 	/* activate_spare will check if the array is degraded and, if it is,
-	 * try to find some spare space in the container.  On success, it add
-	 * appropriate updates (For process_update) to to the 'updates' list
-	 * and returns a list of 'mdinfo' identifying the device, or devices as
+	 * try to find some spare space in the container.  On success, it adds
+	 * appropriate updates (for process_update) to to the 'updates' list
+	 * and returns a list of 'mdinfo' identifying the device (or devices) as
 	 * there might be multiple missing devices and multiple spares
 	 * available.
 	 *

--- a/mdadm.h
+++ b/mdadm.h
@@ -1048,14 +1048,18 @@ extern struct superswitch {
 	int (*prepare_update)(struct supertype *st,
 			       struct metadata_update *update);
 
-	/* activate_spare will check if the array is degraded and, if it
-	 * is, try to find some spare space in the container.
-	 * On success, it add appropriate updates (For process_update) to
-	 * to the 'updates' list and returns a list of 'mdinfo' identifying
-	 * the device, or devices as there might be multiple missing
-	 * devices and multiple spares available.
+	/* activate_spare will check if the array is degraded and, if it is,
+	 * try to find some spare space in the container.  On success, it add
+	 * appropriate updates (For process_update) to to the 'updates' list
+	 * and returns a list of 'mdinfo' identifying the device, or devices as
+	 * there might be multiple missing devices and multiple spares
+	 * available.
+	 *
+	 * Optionally, select a disk for replacement by providing replace=1.
+	 * This ensures only a single replacement disk is activated.
 	 */
 	struct mdinfo *(*activate_spare)(struct active_array *a,
+					 int replace_only,
 					 struct metadata_update **updates);
 	/*
 	 * Return statically allocated string that represents metadata specific

--- a/mdadm.h
+++ b/mdadm.h
@@ -235,8 +235,7 @@ struct dlm_lksb {
 
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
 
-extern char Name[];
-extern __thread const char *ThreadName;
+extern __thread const char *Name;
 
 struct md_bb_entry {
 	unsigned long long sector;
@@ -1644,12 +1643,12 @@ static inline char *to_subarray(struct mdstat_ent *ent, char *container)
 #define DEBUG 1
 #ifdef DEBUG
 #define dprintf(fmt, arg...) \
-	fprintf(stderr, "%s: %s%s: "fmt, Name, ThreadName, __func__, ##arg)
+	fprintf(stderr, "%s: %s: "fmt, Name, __func__, ##arg)
 #define dprintf_cont(fmt, arg...) \
 	fprintf(stderr, fmt, ##arg)
 #else
 #define dprintf(fmt, arg...) \
-        ({ if (0) fprintf(stderr, "%s: %s%s: " fmt, Name, ThreadName, __func__, ##arg); 0; })
+        ({ if (0) fprintf(stderr, "%s: %s: " fmt, Name, __func__, ##arg); 0; })
 #define dprintf_cont(fmt, arg...) \
         ({ if (0) fprintf(stderr, fmt, ##arg); 0; })
 #endif
@@ -1666,7 +1665,7 @@ static inline int xasprintf(char **strp, const char *fmt, ...) {
 }
 
 #ifdef DEBUG
-#define pr_err(fmt, args...) fprintf(stderr, "%s: %s%s: "fmt, Name, ThreadName, __func__, ##args)
+#define pr_err(fmt, args...) fprintf(stderr, "%s: %s: "fmt, Name, __func__, ##args)
 #else
 #define pr_err(fmt, args...) fprintf(stderr, "%s: "fmt, Name, ##args)
 #endif

--- a/mdadm.h
+++ b/mdadm.h
@@ -323,6 +323,7 @@ struct mdinfo {
 	#define DS_WRITE_ERROR  4096
 	#define DS_REPLACEMENT  8192
 	int prev_state, curr_state, next_state;
+	int replace;
 
 	/* info read from sysfs */
 	char		sysfs_array_state[20];

--- a/mdadm.h
+++ b/mdadm.h
@@ -1173,6 +1173,7 @@ struct supertype {
 			 */
 	int devcnt;
 	int retry_soon;
+	int retry_later;
 	int nodes;
 	char *cluster_name;
 

--- a/mdadm.h
+++ b/mdadm.h
@@ -1055,8 +1055,9 @@ extern struct superswitch {
 	 * there might be multiple missing devices and multiple spares
 	 * available.
 	 *
-	 * Optionally, select a disk for replacement by providing replace=1.
-	 * This ensures only a single replacement disk is activated.
+	 * Optionally, select a disk for replacement by providing the
+	 * 'replace_only' boolean set to 1.  This ensures a single disk
+	 * replacement disk only is activated.
 	 */
 	struct mdinfo *(*activate_spare)(struct active_array *a,
 					 int replace_only,

--- a/mdadm.h
+++ b/mdadm.h
@@ -314,15 +314,16 @@ struct mdinfo {
 	int state_fd;
 	int bb_fd;
 	int ubb_fd;
-	#define DS_FAULTY	1
-	#define	DS_INSYNC	2
-	#define	DS_WRITE_MOSTLY	4
-	#define	DS_SPARE	8
-	#define DS_BLOCKED	16
-	#define	DS_REMOVE	1024
-	#define	DS_UNBLOCK	2048
-	#define DS_WRITE_ERROR  4096
-	#define DS_REPLACEMENT  8192
+	#define DS_FAULTY	    (1 << 0)
+	#define	DS_INSYNC	    (1 << 1)
+	#define	DS_WRITE_MOSTLY	    (1 << 2)
+	#define	DS_SPARE	    (1 << 3)
+	#define DS_BLOCKED	    (1 << 4)
+	#define	DS_REMOVE	    (1 << 10)
+	#define	DS_UNBLOCK	    (1 << 11)
+	#define DS_WRITE_ERROR      (1 << 12)
+	#define DS_WANT_REPLACEMENT (1 << 13)
+	#define DS_REPLACEMENT      (1 << 14)
 	int prev_state, curr_state, next_state;
 	int faulty;
 	int replace;
@@ -1032,7 +1033,7 @@ extern struct superswitch {
 	 * set_disk might be called when the state of the particular disk has
 	 * not in fact changed.
 	 */
-	void (*set_disk)(struct active_array *a, mdu_disk_info_t *dsk, int state);
+	int (*set_disk)(struct active_array *a, mdu_disk_info_t *dsk, int state);
 
 	/* Complete the disk replacement. Once a replaced disk goes faulty,
 	 * replace it with the selected replacement in it's slot. This updates

--- a/mdadm.h
+++ b/mdadm.h
@@ -236,6 +236,7 @@ struct dlm_lksb {
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
 
 extern char Name[];
+extern __thread const char *ThreadName;
 
 struct md_bb_entry {
 	unsigned long long sector;
@@ -1639,12 +1640,12 @@ static inline char *to_subarray(struct mdstat_ent *ent, char *container)
 #define DEBUG 1
 #ifdef DEBUG
 #define dprintf(fmt, arg...) \
-	fprintf(stderr, "%s: %s: "fmt, Name, __func__, ##arg)
+	fprintf(stderr, "%s: %s%s: "fmt, Name, ThreadName, __func__, ##arg)
 #define dprintf_cont(fmt, arg...) \
 	fprintf(stderr, fmt, ##arg)
 #else
 #define dprintf(fmt, arg...) \
-        ({ if (0) fprintf(stderr, "%s: %s: " fmt, Name, __func__, ##arg); 0; })
+        ({ if (0) fprintf(stderr, "%s: %s%s: " fmt, Name, ThreadName, __func__, ##arg); 0; })
 #define dprintf_cont(fmt, arg...) \
         ({ if (0) fprintf(stderr, fmt, ##arg); 0; })
 #endif
@@ -1661,7 +1662,7 @@ static inline int xasprintf(char **strp, const char *fmt, ...) {
 }
 
 #ifdef DEBUG
-#define pr_err(fmt, args...) fprintf(stderr, "%s: %s: "fmt, Name, __func__, ##args)
+#define pr_err(fmt, args...) fprintf(stderr, "%s: %s%s: "fmt, Name, ThreadName, __func__, ##args)
 #else
 #define pr_err(fmt, args...) fprintf(stderr, "%s: "fmt, Name, ##args)
 #endif

--- a/mdmon.c
+++ b/mdmon.c
@@ -69,6 +69,7 @@
 #include	"mdvote.h"
 
 char Name[256] = "mdmon";
+__thread const char *ThreadName = "";
 
 struct active_array *discard_this;
 struct active_array *pending_discard;
@@ -395,7 +396,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	snprintf((char *)Name, sizeof Name, "mdmon-%s", container_name);
+	snprintf((char *)Name, sizeof Name, "mdmon@%s", container_name);
 	return mdmon(devnm, dofork && do_fork(), takeover);
 }
 

--- a/mdmon.c
+++ b/mdmon.c
@@ -73,6 +73,7 @@ __thread const char *ThreadName = "";
 
 struct active_array *discard_this;
 struct active_array *pending_discard;
+pthread_mutex_t      array_lock;
 
 int mon_tid, mgr_tid;
 
@@ -457,6 +458,7 @@ static int mdmon(char *devnm, int must_fork, int takeover)
 	strcpy(container->devnm, devnm);
 	container->arrays = NULL;
 	container->sock = -1;
+	pthread_mutex_init(&array_lock, NULL);
 
 	mdi = sysfs_read(mdfd, container->devnm, GET_VERSION|GET_LEVEL|GET_DEVS);
 

--- a/mdmon.c
+++ b/mdmon.c
@@ -68,8 +68,7 @@
 #include	"mdmon.h"
 #include	"mdvote.h"
 
-char Name[256] = "mdmon";
-__thread const char *ThreadName = "";
+__thread const char *Name = "mdmon";
 
 struct active_array *discard_this;
 struct active_array *pending_discard;
@@ -397,7 +396,6 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	snprintf((char *)Name, sizeof Name, "mdmon@%s", container_name);
 	return mdmon(devnm, dofork && do_fork(), takeover);
 }
 

--- a/mdmon.h
+++ b/mdmon.h
@@ -50,6 +50,7 @@ struct active_array {
 	int check_degraded; /* flag set by mon, read by manage */
 	int check_reshape; /* flag set by mon, read by manage */
 	int check_replacement; /* flag set by mon, read by manage */
+	int check_remove; /* flag set by mon, read by manage */
 };
 
 /*
@@ -86,6 +87,7 @@ extern int exit_now, manager_ready;
 extern int mon_tid, mgr_tid;
 extern int monitor_loop_cnt;
 extern int probe_enabled;
+extern pthread_mutex_t array_lock;
 
 /* helper routine to determine resync completion since MaxSector is a
  * moving target

--- a/mdmon.h
+++ b/mdmon.h
@@ -49,6 +49,7 @@ struct active_array {
 
 	int check_degraded; /* flag set by mon, read by manage */
 	int check_reshape; /* flag set by mon, read by manage */
+	int check_replacement; /* flag set by mon, read by manage */
 };
 
 /*

--- a/mdmon.h
+++ b/mdmon.h
@@ -18,7 +18,7 @@
  * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-extern char Name[];
+extern __thread const char *Name;
 
 enum array_state { clear, inactive, suspended, readonly, read_auto,
 		   clean, active, write_pending, active_idle, bad_word};

--- a/mdvote.c
+++ b/mdvote.c
@@ -22,7 +22,7 @@
 #ifndef dprintf
 #define DEBUG 1
 #ifdef DEBUG
-extern char Name[];
+extern __thread const char *Name;
 #define dprintf(fmt, arg...) \
 	fprintf(stderr, "%s: %s: "fmt, Name, __func__, ##arg)
 #define dprintf_cont(fmt, arg...) \

--- a/monitor.c
+++ b/monitor.c
@@ -348,8 +348,6 @@ static void signal_manager(void)
 {
 	/* tgkill(getpid(), mon_tid, SIGUSR1); */
 	int pid = getpid();
-	dprintf("mon_tid: %d\n", mon_tid);
-	dprintf("mgr_tid: %d\n", mgr_tid);
 	syscall(SYS_tgkill, pid, mgr_tid, SIGUSR1);
 }
 
@@ -1141,7 +1139,7 @@ void do_monitor(struct supertype *container)
 	int rv;
 	int first = 1;
 
-	ThreadName = "monitor:";
+	Name = "monitor";
 
 	do {
 		rv = wait_and_act(container, first);

--- a/monitor.c
+++ b/monitor.c
@@ -805,7 +805,7 @@ static void reconcile_failed(struct active_array *aa, struct mdinfo *failed)
 }
 
 #ifdef DEBUG
-static void dprint_wake_reasons(fd_set *fds)
+static void wake_reasons(fd_set *fds)
 {
 	int i;
 	char proc_path[256];
@@ -813,7 +813,7 @@ static void dprint_wake_reasons(fd_set *fds)
 	char *basename;
 	int rv;
 
-	fprintf(stderr, "monitor: wake ( ");
+	dprintf("( ");
 	for (i = 0; i < FD_SETSIZE; i++) {
 		if (FD_ISSET(i, fds)) {
 			sprintf(proc_path, "/proc/%d/fd/%d",
@@ -933,7 +933,7 @@ static int wait_and_act(struct supertype *container, int nowait)
 		}
 		#ifdef DEBUG
 		else
-			dprint_wake_reasons(&rfds);
+			wake_reasons(&rfds);
 		#endif
 		container->retry_soon = 0;
 	}
@@ -997,6 +997,9 @@ void do_monitor(struct supertype *container)
 {
 	int rv;
 	int first = 1;
+
+	ThreadName = "monitor:";
+
 	do {
 		rv = wait_and_act(container, first);
 		first = 0;

--- a/monitor.c
+++ b/monitor.c
@@ -607,7 +607,7 @@ static int read_and_act(struct active_array *a, fd_set *fds)
 			check_degraded = 1;
 
 			/* check replacement on every faulty disk.
-			 * can we race with DS_FAULTY | DS_REPLACEMENT both being set? 
+			 * We can race with DS_FAULTY | DS_REPLACEMENT not both being set as expected.
 			 */
 			check_replacement = 1;
 				

--- a/monitor.c
+++ b/monitor.c
@@ -458,11 +458,12 @@ static int read_and_act(struct active_array *a, fd_set *fds)
 			mdi->curr_state = read_dev_state(mdi->state_fd);
 		}
 
-		dprintf("array%d: disk%d (%d:%d) state: ",
+		dprintf("array%d: disk%d (%d:%d) state: %d: ",
 			a->info.container_member,
 			mdi->disk.raid_disk,
 			mdi->disk.major,
-			mdi->disk.minor);
+			mdi->disk.minor,
+			mdi->curr_state);
 
 		if (mdi->curr_state & (DS_WRITE_ERROR |
 				       DS_FAULTY |
@@ -490,8 +491,9 @@ static int read_and_act(struct active_array *a, fd_set *fds)
 		}
 
 		fprintf(stderr, "%s%s%s\n",
-			mdi->curr_state == 0 ? "online" : "",
-		        mdi->replace ? " (wants replacement)" : "",
+			(mdi->curr_state & DS_INSYNC) ? "online" : "",
+			mdi->remove ? " (removed)" :
+		            mdi->replace ? " (wants replacement)" : "",
 		        mdi->faulty  ? " (faulty)" : "");
 
 		/*
@@ -767,8 +769,6 @@ static int read_and_act(struct active_array *a, fd_set *fds)
 		mdi->prev_state = mdi->curr_state;
 		mdi->next_state = 0;
 	}
-
-	dprintf("check replacement: %d\n", check_replacement);
 
 	if (check_degraded ||
 	    check_reshape ||

--- a/monitor.c
+++ b/monitor.c
@@ -460,7 +460,8 @@ static int read_and_act(struct active_array *a, fd_set *fds)
 				       DS_BLOCKED |
 				       DS_SPARE)) {
 
-			dprintf("disk%d (%d:%d) state: ",
+			dprintf("array%d: disk%d (%d:%d) state: ",
+				a->info.container_member,
 				mdi->disk.raid_disk,
 				mdi->disk.major,
 				mdi->disk.minor);
@@ -479,6 +480,7 @@ static int read_and_act(struct active_array *a, fd_set *fds)
 			}
 			if (mdi->curr_state & DS_REPLACEMENT) {
 				fprintf(stderr, "WANT_REPLACEMENT ");
+				mdi->replace = 1;
 			}
 			fprintf(stderr, "\n");
 		}

--- a/super-ddf.c
+++ b/super-ddf.c
@@ -3504,7 +3504,7 @@ static int __write_ddf_structure(struct dl *d, struct ddf_super *ddf, __u8 type)
 		}
 		if (vdc) {
 			char nbuf[64];
-			dprintf("writing conf record %i on disk refnum:%08x for %s (%s) %u (%d bytes)\n",
+			dprintf(" writing conf record %i on disk refnum:%08x for %s (%s) %u (%d bytes)\n",
 					i, be32_to_cpu(d->disk.refnum),
 					guid_str(vdc->guid),
 					__fname_from_uuid((void *)vdc->uuid, 0, nbuf, ':'),
@@ -4695,13 +4695,13 @@ static int ddf_open_new(struct supertype *c, struct active_array *a, char *inst)
 			    dl->minor == dev->disk.minor)
 				break;
 		if (!dl || dl->pdnum < 0) {
-			pr_err("device %d/%d of subarray %d not found in meta data\n",
+			pr_err("device (%d:%d) of subarray %d not found in meta data\n",
 				dev->disk.major, dev->disk.minor, n);
 			return -1;
 		}
 		if ((be16_to_cpu(ddf->phys->entries[dl->pdnum].state) &
 			(DDF_Online|DDF_Missing|DDF_Failed)) != DDF_Online) {
-			pr_err("new subarray %d contains broken device %d/%d (%02x)\n",
+			pr_err("new subarray %d contains broken device (%d:%d) state:%02x\n",
 			       n, dl->major, dl->minor,
 			       be16_to_cpu(ddf->phys->entries[dl->pdnum].state));
 			if (write(dev->state_fd, faulty, sizeof(faulty)-1) !=
@@ -5098,7 +5098,6 @@ static void ddf_set_disk(struct active_array *a, mdu_disk_info_t *dsk, int state
 	/* and find the 'dl' entry corresponding to that. */
 	for (dl = ddf->dlist; dl; dl = dl->next)
 		if (mdi->state_fd >= 0 &&
-		    mdi->disk.raid_disk == dl->raiddisk && 
 		    mdi->disk.major == dl->major &&
 		    mdi->disk.minor == dl->minor)
 			break;

--- a/super-ddf.c
+++ b/super-ddf.c
@@ -5825,9 +5825,6 @@ static void ddf_remove_failed(struct ddf_super *ddf)
 
 	/*
 	 * remove "disk being removed" from dlist.
-	 *
-	 * This will cause metadata update to remove the physical disk from
-	 * metadata
 	 */
 	struct dl **dlp;
 	for (dlp = &ddf->dlist; *dlp; dlp = &(*dlp)->next) {

--- a/super-ddf.c
+++ b/super-ddf.c
@@ -5297,7 +5297,8 @@ ddf_replace_disk(struct active_array *a, mdu_disk_info_t *dsk,
 		if (mdi->disk.raid_disk == dsk->raid_disk &&
 		    (mdi->disk.major != dsk->major ||
 		     mdi->disk.minor != dsk->minor) &&
-		    !(mdi->curr_state & DS_FAULTY))
+		     (mdi->curr_state & DS_INSYNC) &&
+		    !((mdi->curr_state & DS_FAULTY) || mdi->faulty))
 			break;
 	}
 

--- a/super-intel.c
+++ b/super-intel.c
@@ -8312,6 +8312,7 @@ static int imsm_rebuild_allowed(struct supertype *cont, int dev_idx, int failed)
 }
 
 static struct mdinfo *imsm_activate_spare(struct active_array *a,
+					  int replace_only,
 					  struct metadata_update **updates)
 {
 	/**

--- a/super-intel.c
+++ b/super-intel.c
@@ -7735,7 +7735,7 @@ static unsigned long long imsm_set_array_size(struct imsm_dev *dev,
 	return array_blocks;
 }
 
-static void imsm_set_disk(struct active_array *a, mdu_disk_info_t *dsk, int state);
+static int imsm_set_disk(struct active_array *a, mdu_disk_info_t *dsk, int state);
 
 static void imsm_progress_container_reshape(struct intel_super *super)
 {
@@ -7957,7 +7957,7 @@ static int imsm_disk_slot_to_ord(struct active_array *a, int slot)
 	return get_imsm_ord_tbl_ent(dev, slot, MAP_0);
 }
 
-static void imsm_set_disk(struct active_array *a, mdu_disk_info_t *dsk, int state)
+static int imsm_set_disk(struct active_array *a, mdu_disk_info_t *dsk, int state)
 {
 	int inst = a->info.container_member;
 	struct intel_super *super = a->container->sb;
@@ -7973,7 +7973,7 @@ static void imsm_set_disk(struct active_array *a, mdu_disk_info_t *dsk, int stat
 
 	ord = imsm_disk_slot_to_ord(a, n);
 	if (ord < 0)
-		return;
+		return -1;
 
 	dprintf("imsm: set_disk %d:%x\n", n, state);
 	disk = get_imsm_disk(super, ord_to_idx(ord));
@@ -8092,6 +8092,8 @@ static void imsm_set_disk(struct active_array *a, mdu_disk_info_t *dsk, int stat
 		dprintf_cont("state %i\n", map_state);
 	}
 	dprintf_cont("\n");
+
+	return 1;
 }
 
 static int store_imsm_mpb(int fd, struct imsm_super *mpb)

--- a/super-intel.c
+++ b/super-intel.c
@@ -7735,7 +7735,7 @@ static unsigned long long imsm_set_array_size(struct imsm_dev *dev,
 	return array_blocks;
 }
 
-static void imsm_set_disk(struct active_array *a, int n, int state);
+static void imsm_set_disk(struct active_array *a, mdu_disk_info_t *dsk, int state);
 
 static void imsm_progress_container_reshape(struct intel_super *super)
 {
@@ -7856,7 +7856,7 @@ static int imsm_set_array_state(struct active_array *a, int consistent)
 				/* finalize online capacity expansion/reshape */
 				for (mdi = a->info.devs; mdi; mdi = mdi->next)
 					imsm_set_disk(a,
-						      mdi->disk.raid_disk,
+						      &mdi->disk,
 						      mdi->curr_state);
 
 				imsm_progress_container_reshape(super);
@@ -7957,7 +7957,7 @@ static int imsm_disk_slot_to_ord(struct active_array *a, int slot)
 	return get_imsm_ord_tbl_ent(dev, slot, MAP_0);
 }
 
-static void imsm_set_disk(struct active_array *a, int n, int state)
+static void imsm_set_disk(struct active_array *a, mdu_disk_info_t *dsk, int state)
 {
 	int inst = a->info.container_member;
 	struct intel_super *super = a->container->sb;
@@ -7968,6 +7968,7 @@ static void imsm_set_disk(struct active_array *a, int n, int state)
 	int recovery_not_finished = 0;
 	int failed;
 	int ord;
+	int n = dsk->raid_disk;
 	__u8 map_state;
 
 	ord = imsm_disk_slot_to_ord(a, n);

--- a/sysfs.c
+++ b/sysfs.c
@@ -342,6 +342,8 @@ struct mdinfo *sysfs_read(int fd, char *devnm, unsigned long options)
 				dev->disk.state |= (1<<MD_DISK_SYNC);
 			if (strstr(buf, "faulty"))
 				dev->disk.state |= (1<<MD_DISK_FAULTY);
+			if (strstr(buf, "want_replacement"))
+				dev->disk.state |= (1<<MD_DISK_REPLACEMENT);
 			if (dev->disk.state == 0)
 				sra->array.spare_disks++;
 		}

--- a/systemd/mdmon@.service
+++ b/systemd/mdmon@.service
@@ -6,7 +6,7 @@
 #  (at your option) any later version.
 
 [Unit]
-Description=MD Metadata Monitor on /dev/%I
+Description=MD Metadata Monitor mdmon@%I
 DefaultDependencies=no
 Before=initrd-switch-root.target
 
@@ -14,6 +14,7 @@ Before=initrd-switch-root.target
 # mdmon should never complain due to lack of a platform,
 # that is mdadm's job if at all.
 WorkingDirectory=/bb
+SyslogIdentifier=mdmon@%I
 Environment=IMSM_NO_PLATFORM=1
 EnvironmentFile=-/bb/etc/mdmon.env
 # The mdmon starting in the initramfs (with dracut at least)


### PR DESCRIPTION
Support disk replacement with DDF metadata.

This change consists of two parts. First, we allow mdadm to perform a disk replacement with DDF metadata. The disk in the "member" array is selected for replacement (e.g.: `mdadm --replace /dev/md/array /dev/sdb`)

Then, we allow a spare disk to be "activated" in the member array beyond the number of raid disks. This "spare" is synchronized as if it was a spare replacement, and then is used to immediately "replace" the disk wanting replacement that was set in step one. The kernel automatically marks the disk "wanting replacement" as faulty, as soon as the spare synchronization is completed, so we know when to perform the replacement. The replacement is done entirely within mdmon.

`mdmon` is updated to monitor this synchronization, and perform the disk replacement when ready. Once replacement is complete, the metadata is updated everywhere, and the new replacement disk takes the place of the old disk that wanted replacement.